### PR TITLE
Fix codigoProduto parsing

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -9,6 +9,7 @@ from services.processador_pedido import ProcessadorPedido
 from services.processador_pedido_item import ProcessadorPedidoItem
 from services.validador_cliente import ValidadorCliente
 from services.validador_produto import ValidadorProduto
+from utils.helpers import interpretar_codigo_produto
 from repositories.pedido_repository import PedidoRepository
 from models.pedido import Pedido
 from utils.error_handler import (
@@ -63,10 +64,11 @@ def processar_pedido_neogrid(doc, processador_pedido, repo, api_client=None):
         
         # Processar itens do pedido
         for item in pedido_neogrid.itens:
+            ean13, dun14, codprod = interpretar_codigo_produto(item.codigo_produto)
             item_para_processar = {
-                "ean13": "",  
-                "dun14": "",
-                "codprod": item.codigo_produto,
+                "ean13": ean13,
+                "dun14": dun14,
+                "codprod": codprod,
                 "qtd": float(item.quantidade),
                 "valor": float(item.preco_unitario)
             }

--- a/tests/test_utils/test_helpers.py
+++ b/tests/test_utils/test_helpers.py
@@ -1,0 +1,26 @@
+import sys
+import os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
+
+from utils.helpers import interpretar_codigo_produto
+
+
+def test_interpretar_codigo_produto_ean13():
+    ean, dun, cod = interpretar_codigo_produto("7896524726150")
+    assert ean == "7896524726150"
+    assert dun == ""
+    assert cod == ""
+
+
+def test_interpretar_codigo_produto_dun14():
+    ean, dun, cod = interpretar_codigo_produto("17896524703332")
+    assert ean == ""
+    assert dun == "17896524703332"
+    assert cod == ""
+
+
+def test_interpretar_codigo_produto_codigo_interno():
+    ean, dun, cod = interpretar_codigo_produto("1001.01.03X05L")
+    assert ean == ""
+    assert dun == ""
+    assert cod == "1001.01.03X05L"

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -1,0 +1,21 @@
+import re
+
+def interpretar_codigo_produto(codigo: str):
+    """Interpreta o valor informado em codigoProduto e devolve
+    ean13, dun14 ou codigo interno conforme o formato."""
+    codigo = codigo.strip()
+    ean13 = ""
+    dun14 = ""
+    codprod = ""
+
+    if codigo.isdigit():
+        if len(codigo) == 13:
+            ean13 = codigo
+        elif len(codigo) == 14:
+            dun14 = codigo
+        else:
+            codprod = codigo
+    else:
+        codprod = codigo
+
+    return ean13, dun14, codprod


### PR DESCRIPTION
## Summary
- add helper to interpret codigoProduto as EAN13/DUN14/codprod
- parse codigoProduto correctly when building order items
- test the helper function

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887a9e4ee0c832ca1f5f0853bb22da7