### PR TITLE
Fix date param when verifying orders

### DIFF
--- a/repositories/pedido_repository.py
+++ b/repositories/pedido_repository.py
@@ -86,7 +86,7 @@ class PedidoRepository:
             """
             params = (
                 str(pedido.num_pedido_afv),
-                pedido.data_pedido,
+                self._tratar_data(pedido.data_pedido),
                 pedido.hora_inicio,
                 pedido.codigo_cliente,
             )


### PR DESCRIPTION
## Summary
- ensure `pedido_existe` converts the received date to `datetime` before using it in SQL

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a6f4e4c18832ca659c19642b219f5