### PR TITLE
Start Streamlit sidebar collapsed

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -211,7 +211,7 @@ st.set_page_config(
     page_title="TOTVS | Importador Neogrid",
     page_icon="🔵",
     layout="wide",
-    initial_sidebar_state="expanded"
+    initial_sidebar_state="collapsed"
 )
 
 # Carregar CSS personalizado


### PR DESCRIPTION
## Summary
- collapse sidebar by default in Streamlit app

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cb9e4239c832ca2217341fab36ce6