### PR TITLE
Fix cliente nome_fantasia mapping

### DIFF
--- a/models/cliente.py
+++ b/models/cliente.py
@@ -47,7 +47,7 @@ class Cliente:
         self.fax = kwargs.get("fax", "")
         self.cep = kwargs.get("cep", "")
         self.codigo_status = kwargs.get("codigo_status", "")
-        self.nome_fantasia = nome
+        self.nome_fantasia = kwargs.get("nome_fantasia", nome)
         self.data_cadastro = kwargs.get("data_cadastro", "")
         self.codigo_entrega = kwargs.get("codigo_entrega", "")
         self.codigo_regiao = kwargs.get("codigo_regiao", 0)

--- a/models/pedido_sobel.py
+++ b/models/pedido_sobel.py
@@ -79,7 +79,7 @@ class PedidoSobel(BaseModel):
             observacao_2=pedido_json.get("observacao_2"),
             valor_liquido=pedido_json.get("valor_liquido"),
             valor_bruto=total,
-            codigo_motivo_tipo_ped=pedido_json.get("codigo_motivo_tipo_ped"),
+            codigo_motivo_tipo_pedido=pedido_json.get("codigo_motivo_tipo_pedido"),
             codigo_vendedor_resp=pedido_json.get("codigo_vendedor_resp"),
             data_entrega_fim=pedido_json.get("data_entrega_fim"),
             num_pedido_assoc=pedido_json.get("num_pedido_assoc"),

--- a/tests/test_model/test_pedido_sobel.py
+++ b/tests/test_model/test_pedido_sobel.py
@@ -53,3 +53,28 @@ def test_criacao_pedido_sobel_completo():
     assert pedido.qtde_itens == 2
     assert pedido.valor_total == 400.00
     assert pedido.itens[0].descricao_produto == "Água Sanitária Suprema"
+
+
+def test_from_json_mapeia_codigo_motivo_tipo_pedido():
+    cliente = Cliente(codigo="1", nome="Teste", cnpj="00000000000000")
+    itens = [
+        PedidoItemSobel(
+            cod_produto="1001",
+            descricao_produto="Produto",
+            quantidade=1,
+            valor_unitario=10.0,
+            valor_total=10.0,
+            unidade="CX",
+        )
+    ]
+
+    pedido_json = {
+        "num_pedido": "1",
+        "data_pedido": "2025-01-01",
+        "hora_inicio": "08:00",
+        "codigo_motivo_tipo_pedido": "Z1",
+    }
+
+    pedido = PedidoSobel.from_json(pedido_json, cliente, itens)
+
+    assert pedido.codigo_motivo_tipo_pedido == "Z1"


### PR DESCRIPTION
## Summary
- ensure Cliente model stores `nome_fantasia` returned from DB
- map `codigo_motivo_tipo_pedido` correctly when building `PedidoSobel`
- test codigo_motivo_tipo_pedido mapping

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688cd439bd54832cb0966db3d4c270a7